### PR TITLE
Add possibility to pass inherited classes in generated YAML

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine1/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine1/Yaml/Model/Table.php
@@ -46,6 +46,11 @@ class Table extends BaseTable
         return trim($this->parseComment('externalRelations'));
     }
 
+    public function getInheritances()
+    {
+        return trim($this->parseComment('inheritances'));
+    }
+
     public function getModelName()
     {
         if ($this->isExternal()) {
@@ -107,6 +112,12 @@ class Table extends BaseTable
                 ->outdent()
                 ->close()
             ;
+
+            if ($inheritances = trim($this->getInheritances())) {
+                $writer
+                    ->write($inheritances)
+                ;
+            }
 
             return self::WRITE_OK;
         }

--- a/lib/MwbExporter/Formatter/Doctrine1/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine1/Yaml/Model/Table.php
@@ -110,14 +110,9 @@ class Table extends BaseTable
                         ->writeIf($engine = $this->parameters->get('tableEngine'), 'type: '.$engine)
                     ->outdent()
                 ->outdent()
+                ->writeIf($inheritances = trim($this->getInheritances()), $inheritances)
                 ->close()
             ;
-
-            if ($inheritances = trim($this->getInheritances())) {
-                $writer
-                    ->write($inheritances)
-                ;
-            }
 
             return self::WRITE_OK;
         }


### PR DESCRIPTION
This commit allows to pass to generated YAML Schema additional informations. These are written on 0-depth (root?) level.

I'm using this to generate proper yaml configuration for column_aggregation inheritance type.
http://docs.doctrine-project.org/projects/doctrine1/en/latest/en/manual/inheritance.html

### Example:
Base table name: File
In table comments:
```
{d:inheritances}
ExternalFile:
  inheritance:
    extends: File
    type: column_aggregation
    keyField: type
    keyValue: external
{/d:inheritances}
```